### PR TITLE
Default PactSourceOpts

### DIFF
--- a/src/pact_verifier.erl
+++ b/src/pact_verifier.erl
@@ -212,12 +212,10 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
             undefined ->
                 0;
             _ ->
-                #{
-                    broker_username := BrokerUser,
-                    broker_password := BrokerPassword,
-                    enable_pending := EnablePending,
-                    consumer_version_selectors := ConsumerVersionSelectors
-                } = PactSourceOpts,
+                BrokerUser = maps:get(broker_username, PactSourceOpts, <<"username">>),
+                BrokerPassword = maps:get(broker_password, PactSourceOpts, <<"password">>),
+                EnablePending = maps:get(enable_pending, PactSourceOpts, <<"0">>),
+                ConsumerVersionSelectors = maps:get(consumer_version_selectors, PactSourceOpts, undefined),
                 Args1 = [
                     Name,
                     Scheme,


### PR DESCRIPTION
BROW-1633

If pact broker has public read enabled, we don't need to pass username and password to pact_verifier. Since they will be ignored later on anyway, the easiest option is to default them to some basic values if not provided.
