### PR TITLE
Escape args with special characters in pact_utils

### DIFF
--- a/src/pact_utils.erl
+++ b/src/pact_utils.erl
@@ -6,9 +6,22 @@
 
 -spec run_executable_async(string()) -> {integer(), string()}.
 run_executable_async(Cmd) ->
-    Port = erlang:open_port({spawn, Cmd}, [stream, in, eof, hide, exit_status]),
+    EscapedCmd = escape_special_chars(Cmd),
+    Port = erlang:open_port({spawn, EscapedCmd}, [stream, in, eof, hide, exit_status]),
     get_data_from_executable(Port, []).
 
+escape_special_chars(Cmd) ->
+    %% Split the command into parts and escape them
+    Parts = string:tokens(Cmd, " "),
+    EscapedParts = lists:map(fun escape_part/1, Parts),
+    string:join(EscapedParts, " ").
+
+escape_part(Part) ->
+    %% Check if the part contains special characters and escape it
+    case re:run(Part, "^[\\w\\d\\-]+$") of
+        {match, _} -> Part; %% If it matches a simple word, return as is
+        nomatch -> "'" ++ re:replace(Part, "'", "'\\''", [global, {return, list}]) ++ "'"
+    end.
 get_data_from_executable(Port, Sofar) ->
     receive
         {Port, {data, Bytes}} ->


### PR DESCRIPTION
BROW-1571

If secure passowrd is provided to pact_verifier, it might include special characters that need to be escaped before executing the constructed command.

This change escpaes all parts of the pact verification command that are not simple words.

