### PR TITLE
Add URL verification & more parameters

### DIFF
--- a/c_src/pactffi_nif.c
+++ b/c_src/pactffi_nif.c
@@ -810,8 +810,14 @@ static ERL_NIF_TERM verify_via_url(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
     }
     char *broker_password = convert_erl_binary_to_c_string(env, argv[11]);
 
+    if (!enif_is_binary(env, argv[12]))
+    {
+        return enif_make_badarg(env);
+    }
+    char *build_url = convert_erl_binary_to_c_string(env, argv[12]);
+
     pactffi_verifier_set_verification_options(verifierhandle, 0, 5000),
-    pactffi_verifier_set_publish_options(verifierhandle, version, NULL, NULL, -1, branch);
+    pactffi_verifier_set_publish_options(verifierhandle, version, build_url, NULL, -1, branch);
     pactffi_verifier_url_source(
         verifierhandle,
         pact_url,
@@ -1019,7 +1025,7 @@ static ErlNifFunc nif_funcs[] =
         {"schedule_async_broker_verify", 16, schedule_async_broker_verify},
         {"verify_via_broker", 16, verify_via_broker},
         {"verify_via_file", 10, verify_via_file},
-        {"verify_via_url", 12, verify_via_url}
+        {"verify_via_url", 13, verify_via_url}
     };
 
 ERL_NIF_INIT(pactffi_nif, nif_funcs, NULL, NULL, NULL, NULL)

--- a/c_src/pactffi_nif.c
+++ b/c_src/pactffi_nif.c
@@ -797,13 +797,26 @@ static ERL_NIF_TERM verify_via_url(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
     {
         pactffi_verifier_set_provider_state(verifierhandle, state_path, 0, 1);
     }
+
+    if (!enif_is_binary(env, argv[10]))
+    {
+        return enif_make_badarg(env);
+    }
+    char *broker_username = convert_erl_binary_to_c_string(env, argv[10]);
+
+    if (!enif_is_binary(env, argv[11]))
+    {
+        return enif_make_badarg(env);
+    }
+    char *broker_password = convert_erl_binary_to_c_string(env, argv[11]);
+
     pactffi_verifier_set_verification_options(verifierhandle, 0, 5000),
     pactffi_verifier_set_publish_options(verifierhandle, version, NULL, NULL, -1, branch);
     pactffi_verifier_url_source(
         verifierhandle,
         pact_url,
-        NULL,
-        NULL,
+        broker_username,
+        broker_password,
         NULL
         );
     setenv("PACT_DO_NOT_TRACK", "true", 1);
@@ -1006,7 +1019,7 @@ static ErlNifFunc nif_funcs[] =
         {"schedule_async_broker_verify", 16, schedule_async_broker_verify},
         {"verify_via_broker", 16, verify_via_broker},
         {"verify_via_file", 10, verify_via_file},
-        {"verify_via_url", 10, verify_via_url}
+        {"verify_via_url", 12, verify_via_url}
     };
 
 ERL_NIF_INIT(pactffi_nif, nif_funcs, NULL, NULL, NULL, NULL)

--- a/src/pact_escript.escript
+++ b/src/pact_escript.escript
@@ -46,7 +46,7 @@ main([Module, Function | Args]) ->
                 {[], 0},
                 Args
             ),
-            case length(AList) < 10 of
+            case length(AList) < 12 of
                 true ->
                     AList ++ [<<"">>];
                 false ->

--- a/src/pact_escript.escript
+++ b/src/pact_escript.escript
@@ -30,6 +30,28 @@ main([Module, Function | Args]) ->
                 false ->
                     AList
             end;
+        verify_url_pacts ->
+            {AList, _} =
+            lists:foldl(
+                fun(Arg, {Acc, CountAcc}) ->
+                    A =
+                    case CountAcc of
+                        3 ->
+                            list_to_integer(Arg);
+                        _ ->
+                            list_to_binary(Arg)
+                    end,
+                    {Acc ++ [A], CountAcc + 1}
+                end,
+                {[], 0},
+                Args
+            ),
+            case length(AList) < 10 of
+                true ->
+                    AList ++ [<<"">>];
+                false ->
+                    AList
+            end;
         verify_broker_pacts ->
             {AList1, _} =
             lists:foldl(

--- a/src/pact_escript.escript
+++ b/src/pact_escript.escript
@@ -46,7 +46,7 @@ main([Module, Function | Args]) ->
                 {[], 0},
                 Args
             ),
-            case length(AList) < 12 of
+            case length(AList) < 13 of
                 true ->
                     AList ++ [<<"">>];
                 false ->

--- a/src/pact_verifier.erl
+++ b/src/pact_verifier.erl
@@ -168,12 +168,12 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
     FilePath = maps:get(file_path, PactSourceOpts, undefined),
     PactBrokerUrl = maps:get(broker_url, PactSourceOpts, undefined),
     EscriptPath = code:priv_dir(pact_erlang) ++ "/pact_escript.escript",
-    Output1 =
+    FilePathOutput =
         case FilePath of
             undefined ->
                 0;
             _ ->
-                Args =
+                FilePathArgs =
                     [
                         Name,
                         Scheme,
@@ -186,7 +186,7 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
                         Protocol,
                         StateChangeUrl
                     ],
-                ArgsString =
+                FilePathArgsString =
                     lists:foldl(
                         fun(Arg, Acc) ->
                             A =
@@ -199,15 +199,15 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
                             Acc ++ " " ++ A
                         end,
                         "",
-                        Args
+                        FilePathArgs
                     ),
-                {Output, OutputLog} = pact_utils:run_executable_async(
-                    EscriptPath ++ " pactffi_nif verify_file_pacts " ++ ArgsString
+                {FilePathExecOutput, FilePathExecOutputLog} = pact_utils:run_executable_async(
+                    EscriptPath ++ " pactffi_nif verify_file_pacts " ++ FilePathArgsString
                 ),
-                io:format(OutputLog),
-                Output
+                io:format(FilePathExecOutputLog),
+                FilePathExecOutput
         end,
-    Output2 =
+    PactBrokerOutput =
         case PactBrokerUrl of
             undefined ->
                 0;
@@ -216,7 +216,7 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
                 BrokerPassword = maps:get(broker_password, PactSourceOpts, <<"password">>),
                 EnablePending = maps:get(enable_pending, PactSourceOpts, <<"0">>),
                 ConsumerVersionSelectors = maps:get(consumer_version_selectors, PactSourceOpts, undefined),
-                Args1 = [
+                PactBrokerArgs = [
                     Name,
                     Scheme,
                     Host,
@@ -234,7 +234,7 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
                     SkipPublish,
                     IncludeWipPactsSince
                 ],
-                ArgsString1 =
+                PactBrokerArgsString =
                     lists:foldl(
                         fun(Arg, Acc) ->
                             A =
@@ -247,13 +247,13 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
                             Acc ++ " " ++ A
                         end,
                         "",
-                        Args1
+                        PactBrokerArgs
                     ),
-                {Output3, OutputLog3} = pact_utils:run_executable_async(
-                    EscriptPath ++ " pactffi_nif verify_broker_pacts " ++ ArgsString1
+                {PactBrokerExecOutput, PactBrokerExecOutputLog} = pact_utils:run_executable_async(
+                    EscriptPath ++ " pactffi_nif verify_broker_pacts " ++ PactBrokerArgsString
                 ),
-                io:format(OutputLog3),
-                Output3
+                io:format(PactBrokerExecOutputLog),
+                PactBrokerExecOutput
         end,
     case Protocol of
         <<"message">> ->
@@ -262,7 +262,7 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
         _ ->
             stop_verifier(VerifierRef)
     end,
-    combine_return_codes(Output1, Output2).
+    combine_return_codes(FilePathOutput, PactBrokerOutput).
 
 combine_return_codes(0, 0) -> 0;
 combine_return_codes(Code1, _) when Code1 =/= 0 -> Code1;

--- a/src/pact_verifier.erl
+++ b/src/pact_verifier.erl
@@ -165,6 +165,7 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
     IncludeWipPactsSince = maps:get(include_wip_pacts_since, ProviderOpts, <<"">>),
     SkipPublish = maps:get(skip_publish, ProviderOpts, <<"0">>),
     Scheme = maps:get(scheme, ProviderOpts, <<"http">>),
+    BuildUrl = maps:get(build_url, ProviderOpts, <<"">>),
     FilePath = maps:get(file_path, PactSourceOpts, undefined),
     PactUrl = maps:get(pact_url, PactSourceOpts, undefined),
     PactBrokerUrl = maps:get(broker_url, PactSourceOpts, undefined),
@@ -229,7 +230,8 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
                         Protocol,
                         StateChangeUrl,
                         BrokerUser,
-                        BrokerPassword
+                        BrokerPassword,
+                        BuildUrl
                     ],
                 PactUrlArgsString =
                     lists:foldl(

--- a/src/pact_verifier.erl
+++ b/src/pact_verifier.erl
@@ -168,7 +168,10 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
     FilePath = maps:get(file_path, PactSourceOpts, undefined),
     PactUrl = maps:get(pact_url, PactSourceOpts, undefined),
     PactBrokerUrl = maps:get(broker_url, PactSourceOpts, undefined),
+    BrokerUser = maps:get(broker_username, PactSourceOpts, <<"username">>),
+    BrokerPassword = maps:get(broker_password, PactSourceOpts, <<"password">>),
     EscriptPath = code:priv_dir(pact_erlang) ++ "/pact_escript.escript",
+    
     FilePathOutput =
         case FilePath of
             undefined ->
@@ -224,7 +227,9 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
                         Branch,
                         PactUrl,
                         Protocol,
-                        StateChangeUrl
+                        StateChangeUrl,
+                        BrokerUser,
+                        BrokerPassword
                     ],
                 PactUrlArgsString =
                     lists:foldl(
@@ -252,8 +257,6 @@ verify_pacts(VerifierRef, ProviderOpts, ProviderPortDetails) ->
             undefined ->
                 0;
             _ ->
-                BrokerUser = maps:get(broker_username, PactSourceOpts, <<"username">>),
-                BrokerPassword = maps:get(broker_password, PactSourceOpts, <<"password">>),
                 EnablePending = maps:get(enable_pending, PactSourceOpts, <<"0">>),
                 ConsumerVersionSelectors = maps:get(consumer_version_selectors, PactSourceOpts, undefined),
                 PactBrokerArgs = [

--- a/src/pactffi_nif.erl
+++ b/src/pactffi_nif.erl
@@ -35,13 +35,13 @@
     reify_message/1,
     get_reified_message/1,
     verify_file_pacts/10,
-    verify_url_pacts/12,
+    verify_url_pacts/13,
     verify_broker_pacts/16,
     schedule_async_broker_verify/16,
     schedule_async_file_verify/10,
     verify_via_broker/16,
     verify_via_file/10,
-    verify_via_url/12
+    verify_via_url/13
 ]).
 
 % Import the NIF functions from the C library
@@ -76,7 +76,7 @@
     schedule_async_broker_verify/16,
     verify_via_broker/16,
     verify_via_file/10,
-    verify_via_url/12
+    verify_via_url/13
 ]).
 -on_load(init/0).
 
@@ -198,7 +198,7 @@ schedule_async_broker_verify(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, 
 verify_via_file(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10) ->
     erlang:nif_error("NIF library not loaded").
 
-verify_via_url(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12) ->
+verify_via_url(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13) ->
     erlang:nif_error("NIF library not loaded").
 
 verify_via_broker(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16) ->
@@ -219,10 +219,34 @@ verify_file_pacts(
 % ).
 
 verify_url_pacts(
-    Name, Scheme, Host, Port, Path, Version, Branch, PactUrl, Protocol, StatePath, BrokerUser, BrokerPassword
+    Name,
+    Scheme,
+    Host,
+    Port,
+    Path,
+    Version,
+    Branch,
+    PactUrl,
+    Protocol,
+    StatePath,
+    BrokerUser,
+    BrokerPassword,
+    BuildUrl
 ) ->
     verify_via_url(
-        Name, Scheme, Host, Port, Path, Version, Branch, PactUrl, Protocol, StatePath, BrokerUser, BrokerPassword
+        Name,
+        Scheme,
+        Host,
+        Port,
+        Path,
+        Version,
+        Branch,
+        PactUrl,
+        Protocol,
+        StatePath,
+        BrokerUser,
+        BrokerPassword,
+        BuildUrl
     ).
 
 verify_broker_pacts(

--- a/src/pactffi_nif.erl
+++ b/src/pactffi_nif.erl
@@ -35,11 +35,13 @@
     reify_message/1,
     get_reified_message/1,
     verify_file_pacts/10,
+    verify_url_pacts/10,
     verify_broker_pacts/16,
     schedule_async_broker_verify/16,
     schedule_async_file_verify/10,
     verify_via_broker/16,
-    verify_via_file/10
+    verify_via_file/10,
+    verify_via_url/10
 ]).
 
 % Import the NIF functions from the C library
@@ -73,7 +75,8 @@
     schedule_async_file_verify/10,
     schedule_async_broker_verify/16,
     verify_via_broker/16,
-    verify_via_file/10
+    verify_via_file/10,
+    verify_via_url/10
 ]).
 -on_load(init/0).
 
@@ -195,6 +198,9 @@ schedule_async_broker_verify(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, 
 verify_via_file(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10) ->
     erlang:nif_error("NIF library not loaded").
 
+verify_via_url(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10) ->
+    erlang:nif_error("NIF library not loaded").
+
 verify_via_broker(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16) ->
     erlang:nif_error("NIF library not loaded").
 
@@ -211,6 +217,13 @@ verify_file_pacts(
 % verify_via_file(
 %     Name, Scheme, Host, Port, Path, Version, Branch, FilePath, Protocol, Pid, StatePath, SkipPublish
 % ).
+
+verify_url_pacts(
+    Name, Scheme, Host, Port, Path, Version, Branch, PactUrl, Protocol, StatePath
+) ->
+    verify_via_url(
+        Name, Scheme, Host, Port, Path, Version, Branch, PactUrl, Protocol, StatePath
+    ).
 
 verify_broker_pacts(
     Name,

--- a/src/pactffi_nif.erl
+++ b/src/pactffi_nif.erl
@@ -35,13 +35,13 @@
     reify_message/1,
     get_reified_message/1,
     verify_file_pacts/10,
-    verify_url_pacts/10,
+    verify_url_pacts/12,
     verify_broker_pacts/16,
     schedule_async_broker_verify/16,
     schedule_async_file_verify/10,
     verify_via_broker/16,
     verify_via_file/10,
-    verify_via_url/10
+    verify_via_url/12
 ]).
 
 % Import the NIF functions from the C library
@@ -76,7 +76,7 @@
     schedule_async_broker_verify/16,
     verify_via_broker/16,
     verify_via_file/10,
-    verify_via_url/10
+    verify_via_url/12
 ]).
 -on_load(init/0).
 
@@ -198,7 +198,7 @@ schedule_async_broker_verify(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, 
 verify_via_file(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10) ->
     erlang:nif_error("NIF library not loaded").
 
-verify_via_url(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10) ->
+verify_via_url(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12) ->
     erlang:nif_error("NIF library not loaded").
 
 verify_via_broker(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16) ->
@@ -219,10 +219,10 @@ verify_file_pacts(
 % ).
 
 verify_url_pacts(
-    Name, Scheme, Host, Port, Path, Version, Branch, PactUrl, Protocol, StatePath
+    Name, Scheme, Host, Port, Path, Version, Branch, PactUrl, Protocol, StatePath, BrokerUser, BrokerPassword
 ) ->
     verify_via_url(
-        Name, Scheme, Host, Port, Path, Version, Branch, PactUrl, Protocol, StatePath
+        Name, Scheme, Host, Port, Path, Version, Branch, PactUrl, Protocol, StatePath, BrokerUser, BrokerPassword
     ).
 
 verify_broker_pacts(


### PR DESCRIPTION
BROW-1572

The changes in this PR are required for reaching Platinum level
of Pact Nirvana.

Verifying via URL is essential for running provider verification
job during consumer pipelines. This functionality is essentially
a duplicate of `file_path` verification process with the exception
of using a different FFI function in the end.

Additionally, add basic auth support and build_url parameter
