### PR TITLE
Use MIX_ENV in code path

### DIFF
--- a/src/pact_escript.escript
+++ b/src/pact_escript.escript
@@ -3,7 +3,8 @@
 
 main([Module, Function | Args]) ->
     {ok, Dir} = file:get_cwd(),
-    code:add_pathz(Dir ++ "/_build/test/lib/pact_erlang/ebin"),
+    MixEnv = os:getenv("MIX_ENV", "test"),
+    code:add_pathz(Dir ++ "/_build/" ++ MixEnv ++ "/lib/pact_erlang/ebin"),
     ModuleAtom = list_to_atom(Module),
     FunctionAtom = list_to_atom(Function),
     ArgsList =


### PR DESCRIPTION
Previously _build/test was hardcoded as the compiled build path.
Instead of hardcoding, now we use the mix env in the build path
with test as a default. This enables using other environments
beside test for contract testing.

Upgrade to https://github.com/salemove/pact_erlang/commit/cf115fef7279ac53a5cc946b7dac43845ebba69c